### PR TITLE
fix(deps): Make AMAT work with newer Python installations

### DIFF
--- a/AMAT/arrival.py
+++ b/AMAT/arrival.py
@@ -138,10 +138,10 @@ class Arrival:
 										   self.arrivalPlanet_eph[1].y.value / 86400,
 										   self.arrivalPlanet_eph[1].z.value / 86400])
 
-		(self.v_dep, self.v_arr), = iod.izzo.lambert(Sun.k, self.lastFlybyPlanet_pos * u.km,
-													 self.arrivalPlanet_pos * u.km,
-													 self.TOF,
-													 M=M, numiter=numiter, rtol=rtol)
+		(self.v_dep, self.v_arr) = iod.izzo.lambert(Sun.k, self.lastFlybyPlanet_pos * u.km,
+												    self.arrivalPlanet_pos * u.km,
+													self.TOF,
+													M=M, numiter=numiter, rtol=rtol)
 
 		self.v_inf_vec = self.v_arr.value - self.arrivalPlanet_vel
 		self.v_inf_mag = LA.norm(self.v_inf_vec)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='AMAT',
       license='GPL-3.0-or-later',
       packages=['AMAT'],
       install_requires=['numpy==1.22.0', 'scipy==1.8.0', 'matplotlib==3.5.2', 'pandas==1.4.2',
-                        'astropy==4.3.1', 'jplephem==2.17', 'poliastro==0.16.2'],
+                        'astropy>=5.2', 'jplephem==2.17', 'poliastro==0.17'],
       classifiers=[
         # How mature is this project? Common values are
         #   3 - Alpha
@@ -36,7 +36,7 @@ setup(name='AMAT',
 
 
     include_package_data=False,
-    
+
     package_data = {
       'AMAT' : ['tests/*']
   },


### PR DESCRIPTION
* Newer Python (3.9+) installations cannot use older versions of `astropy` because of https://github.com/pallets/jinja/issues/1586.
* Furthermore, a similar dependency problem arises with `poliastro`.
* This bumps the dependencies and fixes the `poliastro` interface use.